### PR TITLE
fix: correct recipient encoding in `MTokenReceived` event

### DIFF
--- a/.changelog/config.toml
+++ b/.changelog/config.toml
@@ -1,0 +1,1 @@
+project_url = "https://github.com/noble-assets/dollar"

--- a/.changelog/v1.0.0/summary.md
+++ b/.changelog/v1.0.0/summary.md
@@ -1,0 +1,3 @@
+*Feb 28, 2025*
+
+Initial release of the `x/dollar` module, enabling the issuance of the Noble Dollar ($USDN).

--- a/.changelog/v1.0.1/bug-fixes/27-recipient-encoding.md
+++ b/.changelog/v1.0.1/bug-fixes/27-recipient-encoding.md
@@ -1,0 +1,1 @@
+- Correctly encode the recipient address in the `MTokenReceived` event. ([#27](https://github.com/noble-assets/dollar/pull/27))

--- a/.changelog/v1.0.1/summary.md
+++ b/.changelog/v1.0.1/summary.md
@@ -1,0 +1,3 @@
+*Mar 4, 2025*
+
+This is a non-consensus breaking patch to the `v1` release line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# CHANGELOG
+
+## v1.0.1
+
+*Mar 4, 2025*
+
+This is a non-consensus breaking patch to the `v1` release line.
+
+### BUG FIXES
+
+- Correctly encode the recipient address in the `MTokenReceived` event. ([#27](https://github.com/noble-assets/dollar/pull/27))
+
+## v1.0.0
+
+*Feb 28, 2025*
+
+Initial release of the `x/dollar` module, enabling the issuance of the Noble Dollar ($USDN).
+

--- a/keeper/keeper.go
+++ b/keeper/keeper.go
@@ -367,7 +367,7 @@ func (k *Keeper) HandlePayload(ctx context.Context, payload []byte, eventsPayloa
 			return err
 		}
 
-		recipient, err := k.address.BytesToString(tokenPayload.Recipient[12:])
+		recipient, err := k.address.BytesToString(tokenPayload.Recipient)
 		if err != nil {
 			return fmt.Errorf("error encoding the recipient address: %w", err)
 		}


### PR DESCRIPTION
Because we already trim the recipient address in [`payload.go#L82`](https://github.com/noble-assets/dollar/blob/v1.0.0/types/portal/payload.go#L82), there's no need to trim the address again for the event!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new module enabling issuance and management of the Noble Dollar ($USDN).

- **Bug Fixes**
  - Corrected and refined recipient address handling to ensure accurate event notifications.

- **Documentation**
  - Updated configuration with a project repository link.
  - Added a comprehensive changelog detailing release history and non-breaking updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->