### PR TITLE
fix: correctly register `MsgSetYieldRecipient` in codecs

### DIFF
--- a/.changelog/v2.0.2/bug-fixes/47-codec-registrations.md
+++ b/.changelog/v2.0.2/bug-fixes/47-codec-registrations.md
@@ -1,0 +1,1 @@
+- Correctly register `MsgSetYieldRecipient` in codecs. ([#47](https://github.com/noble-assets/dollar/pull/47))

--- a/.changelog/v2.0.2/summary.md
+++ b/.changelog/v2.0.2/summary.md
@@ -1,0 +1,3 @@
+*Jul 8, 2025*
+
+This is a non-consensus breaking patch to the `v2` release line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v2.0.2
+
+*Jul 8, 2025*
+
+This is a non-consensus breaking patch to the `v2` release line.
+
+### BUG FIXES
+
+- Correctly register `MsgSetYieldRecipient` in codecs. ([#47](https://github.com/noble-assets/dollar/pull/47))
+
 ## v2.0.1
 
 *Jul 2, 2025*

--- a/types/v2/codec.go
+++ b/types/v2/codec.go
@@ -28,11 +28,11 @@ import (
 )
 
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-	cdc.RegisterConcrete(&MsgSetYieldRecipientResponse{}, "dollar/SetYieldRecipient", nil)
+	cdc.RegisterConcrete(&MsgSetYieldRecipient{}, "dollar/SetYieldRecipient", nil)
 }
 
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
-	registry.RegisterImplementations((*sdk.Msg)(nil), &MsgSetYieldRecipientResponse{})
+	registry.RegisterImplementations((*sdk.Msg)(nil), &MsgSetYieldRecipient{})
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }


### PR DESCRIPTION
While adding support for this message in the Keplr Multisig service, the Keplr team notified us that the codec registrations for this message were incorrect. This PR resolves this!