### PR TITLE
ci: add action to check licenses

### DIFF
--- a/.github/workflows/check-license.yaml
+++ b/.github/workflows/check-license.yaml
@@ -1,0 +1,18 @@
+name: Check Licenses
+on:
+  pull_request:
+
+jobs:
+  check-license:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: Install go-license
+        run: go install github.com/palantir/go-license@latest
+      - name: Check License
+        run: make check-license

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ FILES := $(shell find . -name "*.go" -not -path "./simapp/*" -not -name "*.pb.go
 license:
 	@go-license --config .github/license.yml $(FILES)
 
+check-license:
+	@go-license --config .github/license.yml $(FILES) --verify
+
 format:
 	@echo "🤖 Running formatter..."
 	@go run $(gofumpt_cmd) -l -w .


### PR DESCRIPTION
This PR adds a Github action to run the `go-license` tool in CI.
