### PR TITLE
fix: remove initializer modifier from child contracts

### DIFF
--- a/contracts/bun.lock
+++ b/contracts/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@noble-assets/usdn",

--- a/contracts/src/HyperliquidNobleDollar.sol
+++ b/contracts/src/HyperliquidNobleDollar.sol
@@ -30,7 +30,7 @@ contract NobleDollar is BaseNobleDollar {
 
     constructor(address mailbox_) BaseNobleDollar(mailbox_) {}
 
-    function initialize(address hook_, address ism_, uint32 tokenId_) public initializer {
+    function initialize(address hook_, address ism_, uint32 tokenId_) public {
         super.initialize(hook_, ism_);
 
         // According to the Hyperliquid documentation, this is how you derive the

--- a/contracts/src/NobleDollar.sol
+++ b/contracts/src/NobleDollar.sol
@@ -89,7 +89,7 @@ contract NobleDollar is HypERC20, UUPSUpgradeable {
         _disableInitializers();
     }
 
-    function initialize(address hook_, address ism_) public virtual initializer {
+    function initialize(address hook_, address ism_) public virtual {
         super.initialize("Noble Dollar", "USDN", hook_, ism_, msg.sender);
 
         _getUSDNStorage().index = IndexingMath.EXP_SCALED_ONE;

--- a/contracts/test/NobleDollar.t.sol
+++ b/contracts/test/NobleDollar.t.sol
@@ -44,12 +44,12 @@ contract NobleDollarTest is Test {
     address constant USER1 = 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045;
     address constant USER2 = 0xF2f1ACbe0BA726fEE8d75f3E32900526874740BB;
     uint32 constant TOKENID = 377;
-    address OWNER;
+    address owner;
 
     function setUp() public {
         vm.createSelectFork("mainnet");
 
-        OWNER = vm.addr(5);
+        owner = vm.addr(5);
         NobleDollar implementation = new NobleDollar(MAILBOX);
 
         // deploy the proxy
@@ -69,8 +69,8 @@ contract NobleDollarTest is Test {
         bytes32[] memory routers = new bytes32[](1);
         routers[0] = 0x726f757465725f61707000000000000000000000000000010000000000000000;
         usdn.enrollRemoteRouters(domains, routers);
-        // Give ownership to OWNER to test bridge claim and upgrades
-        usdn.transferOwnership(OWNER);
+        // Give ownership to owner to test bridge claim and upgrades
+        usdn.transferOwnership(owner);
     }
 
     function test() public {
@@ -579,7 +579,7 @@ contract NobleDollarTest is Test {
 
         // Verify post-claim state
         assertEq(usdn.balanceOf(bridgeAddress), 1e12, "Bridge balance should still be the original");
-        assertEq(usdn.balanceOf(OWNER), 1e12, "Owner should have received the yield tokens");
+        assertEq(usdn.balanceOf(owner), 1e12, "Owner should have received the yield tokens");
         assertEq(usdn.balanceOf(address(usdn)), 0, "Contract balance should be zero after full claim");
         assertEq(usdn.yield(bridgeAddress), 0, "Bridge should have no claimable yield after claiming");
         assertEq(usdn.principalOf(bridgeAddress), 5e11, "Bridge principal should now be halved");
@@ -597,7 +597,7 @@ contract NobleDollarTest is Test {
         usdn.upgradeToAndCall(address(newImplementation), "");
 
         // upgrade from owner account should succeed
-        vm.prank(OWNER);
+        vm.prank(owner);
         usdn.upgradeToAndCall(address(newImplementation), "");
         NobleDollarV2 upgraded = NobleDollarV2(address(usdn));
 


### PR DESCRIPTION
The initializer modifier is already being used during

```solidity
    function initialize(
        string memory _name,
        string memory _symbol,
        address _hook,
        address _interchainSecurityModule,
        address _owner
    ) public virtual initializer {
```

when calling `super.initialize`. So it's not needed in the child contracts.

This was currently preventing me from deploying using Create3 because it wouldn't allow me to do a 2 step deployment (first deploying the proxy and then initializing it). Since we are setting the owner as msg.sender during initialization:
```solidity
super.initialize("Noble Dollar", "USDN", hook_, ism_, msg.sender);
```
when passing the initData to Create3 it would set the owner as the temporary proxy that is created and destroying during the deployment using Create3 (which is some random address, making us lose ownership of the contract), therefore I first deploy without initializing and then initialize it immediately after deployed with the deployer's key. Unfortunately having multiple "initializer" modifiers invalidates initializing in 2 steps because with multiple initializer modifiers in the inheritance chain, 2-step initialization only works during constructor context (address(this).code.length == 0) and we can't do it during constructor context because we want the owner to be msg.sender.